### PR TITLE
Potential fix for code scanning alert no. 4: User-controlled data in numeric cast

### DIFF
--- a/netty4/alpini-netty4-base/src/main/java/com/linkedin/alpini/netty4/misc/BasicHttpObjectDecoder.java
+++ b/netty4/alpini-netty4-base/src/main/java/com/linkedin/alpini/netty4/misc/BasicHttpObjectDecoder.java
@@ -275,7 +275,9 @@ public abstract class BasicHttpObjectDecoder extends HttpObjectDecoder {
           return;
         }
       case READ_CHUNKED_CONTENT: { // SUPPRESS CHECKSTYLE FallThroughCheck
-        assert chunkSize <= Integer.MAX_VALUE;
+        if (chunkSize > Integer.MAX_VALUE) {
+            throw new IllegalArgumentException("chunkSize is too large to be cast to an int: " + chunkSize);
+        }
         int toRead = Math.min((int) chunkSize, maxChunkSize);
         toRead = Math.min(toRead, buffer.readableBytes());
         if (toRead == 0) {


### PR DESCRIPTION
Potential fix for [https://github.com/atcurtis/alpini/security/code-scanning/4](https://github.com/atcurtis/alpini/security/code-scanning/4)

To fix the problem, we need to validate the `chunkSize` value before casting it to an `int`. Specifically, we should ensure that `chunkSize` is within the range of valid `int` values. If `chunkSize` is outside this range, we should handle it appropriately, such as by throwing an exception or logging an error.

We will add a guard to check the range of `chunkSize` before performing the cast. This change will be made in the `READ_CHUNKED_CONTENT` case block.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
